### PR TITLE
fix: 크로스 플랫폼 빌드 지원 및 asar 활성화

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint",
     "electron:dev": "concurrently \"npm run dev\" \"wait-on http://localhost:3000 && cross-env NODE_ENV=development electron .\"",
     "electron:build": "next build && npm run copy-assets && electron-builder",
-    "copy-assets": "cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public"
+    "copy-assets": "node scripts/copy-assets.js"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",
@@ -65,7 +65,11 @@
       "public/**/*",
       "notes/**/*"
     ],
-    "asar": false,
+    "asar": true,
+    "asarUnpack": [
+      "**/.next/standalone/**/*",
+      "**/notes/**/*"
+    ],
     "directories": {
       "buildResources": "assets"
     },

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Recursively copy directory
+ */
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) {
+    console.log(`Source directory does not exist: ${src}`);
+    return;
+  }
+
+  // Create destination directory if it doesn't exist
+  if (!fs.existsSync(dest)) {
+    fs.mkdirSync(dest, { recursive: true });
+  }
+
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+console.log('Copying Next.js build assets...');
+
+// Copy static files
+const staticSrc = path.join('.next', 'static');
+const staticDest = path.join('.next', 'standalone', '.next', 'static');
+copyDir(staticSrc, staticDest);
+console.log('✓ Copied .next/static');
+
+// Copy public files
+const publicSrc = 'public';
+const publicDest = path.join('.next', 'standalone', 'public');
+copyDir(publicSrc, publicDest);
+console.log('✓ Copied public');
+
+console.log('Asset copying completed!');


### PR DESCRIPTION
## 문제

GitHub Actions에서 모든 플랫폼(macOS, Windows, Linux) 빌드가 실패했습니다.

**원인:**
1. `cp -r` 명령이 Windows에서 작동하지 않음
2. `asar: false` 설정으로 인한 경고

## 해결

### 1. 크로스 플랫폼 asset 복사
- `scripts/copy-assets.js` 추가: Node.js 파일 시스템 API 사용
- 모든 플랫폼(Windows, macOS, Linux)에서 동일하게 작동
- `.next/static`과 `public` 폴더를 standalone 디렉토리로 복사

### 2. asar 활성화
- `asar: true`로 변경하여 electron-builder 권장사항 준수
- `asarUnpack`에 필요한 파일 지정:
  - `.next/standalone/**/*`: Next.js 서버 파일
  - `notes/**/*`: 사용자 노트 파일

## 테스트

로컬 빌드 테스트 후 GitHub Actions에서 멀티 플랫폼 빌드 검증 필요