### PR TITLE
fix: asarUnpack 패턴 단순화

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     ],
     "asar": true,
     "asarUnpack": [
-      "**/.next/standalone/**/*",
-      "**/notes/**/*"
+      ".next/standalone/**",
+      "notes/**"
     ],
     "directories": {
       "buildResources": "assets"


### PR DESCRIPTION
## 문제

electron-builder의 asar 패키징 중 에러 발생:
```
⨯ pattern is too long
TypeError: pattern is too long
at isUnpackedDir (@electron/asar/src/asar.ts:23:47)
```

**원인:** `asarUnpack` 패턴이 너무 복잡함
- `**/.next/standalone/**/*` - 이중 globstar로 인한 패턴 복잡도 증가
- `**/notes/**/*` - 동일한 문제

## 해결

asarUnpack 패턴을 단순화:
```json
"asarUnpack": [
  ".next/standalone/**",  // **/* 제거
  "notes/**"              // 시작 부분 **/ 제거
]
```

단순한 glob 패턴으로 동일한 기능을 수행하면서 minimatch 제한을 우회