### PR TITLE
fix: asar 비활성화로 빌드 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,7 @@
       "public/**/*",
       "notes/**/*"
     ],
-    "asar": true,
-    "asarUnpack": [
-      ".next/standalone/**",
-      "notes/**"
-    ],
+    "asar": false,
     "directories": {
       "buildResources": "assets"
     },


### PR DESCRIPTION
## 문제

asarUnpack 패턴을 단순화해도 여전히 빌드 실패:
```
⨯ pattern is too long
TypeError: pattern is too long
```

**원인:** `.next/standalone` 내부의 깊은 디렉토리 구조(node_modules 등)로 인해 파일 경로가 minimatch 한계 초과

## 해결

`asar: false`로 복원
- electron-builder 경고는 나오지만 실제 동작에는 문제 없음
- 모든 파일이 압축되지 않은 상태로 배포되어 안정적으로 작동
- Next.js standalone과 동적 파일 접근에 더 적합

## 참고

asar 비활성화 이유:
- Next.js 서버 파일의 동적 실행
- notes 폴더의 런타임 읽기/쓰기
- 이미지 업로드 등 파일 시스템 접근