### PR TITLE
fix: macOS와 Windows만 빌드하도록 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -45,15 +45,6 @@ jobs:
           name: windows-installer
           path: dist/*.exe
 
-      - name: Upload artifacts (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-packages
-          path: |
-            dist/*.AppImage
-            dist/*.deb
-
   release:
     needs: build
     runs-on: ubuntu-latest
@@ -78,8 +69,6 @@ jobs:
           files: |
             artifacts/macos-dmg/*.dmg
             artifacts/windows-installer/*.exe
-            artifacts/linux-packages/*.AppImage
-            artifacts/linux-packages/*.deb
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## 변경 사항

GitHub Actions workflow에서 ubuntu-latest 빌드 제거

**수정 내용:**
- matrix.os에서 `ubuntu-latest` 제거
- Linux artifact 업로드 단계 제거  
- Release files에서 AppImage/deb 제거

**이유:**
- Ubuntu 빌드에서 asar 패턴 길이 문제로 지속적으로 실패
- macOS와 Windows 빌드는 정상 작동 확인 필요
- Linux 지원은 추후 문제 해결 후 추가 예정

**빌드 플랫폼:**
- ✅ macOS (DMG)
- ✅ Windows (EXE)
- ⏸️  Linux (일시 중단)