### PR TITLE
fix: macOS와 Windows 빌드 지원

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -45,15 +45,6 @@ jobs:
           name: windows-installer
           path: dist/*.exe
 
-      - name: Upload artifacts (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-packages
-          path: |
-            dist/*.AppImage
-            dist/*.deb
-
   release:
     needs: build
     runs-on: ubuntu-latest
@@ -78,8 +69,6 @@ jobs:
           files: |
             artifacts/macos-dmg/*.dmg
             artifacts/windows-installer/*.exe
-            artifacts/linux-packages/*.AppImage
-            artifacts/linux-packages/*.deb
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## 변경 사항

### 1. 크로스 플랫폼 빌드 스크립트
- Node.js 기반 asset 복사 스크립트 추가 (`scripts/copy-assets.js`)
- Windows에서도 정상 작동하도록 개선

### 2. GitHub Actions 빌드 플랫폼 조정
- Ubuntu 빌드 임시 제거 (asar 패턴 문제)
- macOS와 Windows만 빌드하도록 수정

## 빌드 플랫폼

- ✅ macOS (Intel + Apple Silicon DMG)
- ✅ Windows (NSIS 인스톨러)
- ⏸️ Linux (추후 지원 예정)

## 테스트

v0.1.0 태그로 GitHub Actions 자동 빌드 검증 필요