### PR TITLE
워크플로우 단순화 및 macOS 전용 빌드로 변경

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -30,58 +26,21 @@ jobs:
         run: npm ci
 
       - name: Build Electron app
-        if: matrix.os == 'windows-latest'
         run: npm run electron:build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build macOS app (without DMG)
-        if: matrix.os == 'macos-latest'
-        run: |
-          npm run build
-          npm run copy-assets
-          npx electron-builder --mac --arm64 --dir
-          npx electron-builder --mac --x64 --dir
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sign macOS app (ad-hoc)
-        if: matrix.os == 'macos-latest'
-        run: |
-          # Find and sign all .app bundles with ad-hoc signature
-          find dist -name "*.app" -type d | while read app; do
-            echo "Signing $app"
-            codesign --force --deep --sign - "$app"
-          done
-
-      - name: Create macOS DMG
-        if: matrix.os == 'macos-latest'
-        run: |
-          npx electron-builder --mac dmg --prepackaged "dist/mac-arm64/Synapse.app"
-          npx electron-builder --mac dmg --prepackaged "dist/mac/Synapse.app" --x64
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Package macOS DMG
-        if: matrix.os == 'macos-latest'
         run: |
           cd dist
           zip -ry ../macos-installers.zip *.dmg
           cd ..
 
-      - name: Upload artifacts (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg
           path: macos-installers.zip
-
-      - name: Upload artifacts (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-installer
-          path: dist/*.exe
 
   release:
     needs: build
@@ -112,9 +71,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            artifacts/macos-dmg/*.dmg
-            artifacts/windows-installer/*.exe
+          files: artifacts/macos-dmg/*.dmg
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@
 
 [Releases](https://github.com/thewronghand/synapse/releases) 페이지에서 운영체제에 맞는 설치 파일을 다운로드하세요:
 
-- **macOS**: `Synapse-{version}-arm64.dmg` (Apple Silicon) 또는 `Synapse-{version}-x64.dmg` (Intel)
-- **Windows**: `Synapse Setup {version}.exe`
-- **Linux**: `Synapse-{version}.AppImage` 또는 `synapse_{version}_amd64.deb`
+- **macOS**: `Synapse-{version}-arm64.dmg` (Apple Silicon) 또는 `Synapse-{version}.dmg` (Intel)
 
 노트는 자동으로 `~/Documents/Synapse/notes/`에 저장됩니다.
+
+#### macOS 보안 경고 해결
+
+macOS에서 "손상되어 열 수 없습니다" 또는 "확인할 수 없습니다" 경고가 나타나면, 터미널에서 다음 명령어를 실행하세요:
+
+```bash
+xattr -cr /Applications/Synapse.app
+```
+
+그 후 앱을 다시 실행하면 정상적으로 열립니다.
 
 ### 개발 환경 설정
 

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
         "target": "dmg",
         "arch": ["arm64", "x64"]
       },
-      "icon": "assets/synapse-icon-ios.icns",
-      "identity": null
+      "icon": "assets/synapse-icon-ios.icns"
     },
     "dmg": {
       "title": "${productName} ${version}",


### PR DESCRIPTION
## 변경 사항

### 워크플로우 개선
- ad-hoc 코드 서명 단계 제거 (실질적 효과 없음)
- 빌드 프로세스 단순화 (3단계 → 1단계)
- Windows 빌드 제거 (macOS에 집중)

### README 업데이트
- macOS 보안 경고 해결 방법 추가 (`xattr -cr` 명령어)
- 지원 플랫폼 정보 업데이트 (macOS만)

### package.json
- `identity: null` 설정 제거

## 테스트 완료
- 로컬 빌드 확인
- GitHub Actions 빌드 예정