### PR TITLE
Release: 워크플로우 개선 및 macOS 전용 빌드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,13 @@ on:
   push:
     tags:
       - 'v*.*.*'  # Triggers on version tags like v0.1.0, v1.2.3, etc.
+    branches:
+      - 'fix/**'  # Test builds on fix branches
+  workflow_dispatch:  # Manual trigger
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
+    runs-on: macos-latest
 
     steps:
       - name: Checkout code
@@ -31,22 +30,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload artifacts (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Package macOS DMG
+        run: |
+          cd dist
+          zip -ry ../macos-installers.zip *.dmg
+          cd ..
+
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg
-          path: dist/*.dmg
-
-      - name: Upload artifacts (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-installer
-          path: dist/*.exe
+          path: macos-installers.zip
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')  # Only create release for tags
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -60,15 +58,20 @@ jobs:
         with:
           path: artifacts
 
+      - name: Extract macOS DMG
+        run: |
+          cd artifacts/macos-dmg
+          unzip macos-installers.zip
+          rm macos-installers.zip
+          cd ../..
+
       - name: Display artifact structure
         run: ls -R artifacts/
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            artifacts/macos-dmg/*.dmg
-            artifacts/windows-installer/*.exe
+          files: artifacts/macos-dmg/*.dmg
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@
 
 [Releases](https://github.com/thewronghand/synapse/releases) 페이지에서 운영체제에 맞는 설치 파일을 다운로드하세요:
 
-- **macOS**: `Synapse-{version}-arm64.dmg` (Apple Silicon) 또는 `Synapse-{version}-x64.dmg` (Intel)
-- **Windows**: `Synapse Setup {version}.exe`
-- **Linux**: `Synapse-{version}.AppImage` 또는 `synapse_{version}_amd64.deb`
+- **macOS**: `Synapse-{version}-arm64.dmg` (Apple Silicon) 또는 `Synapse-{version}.dmg` (Intel)
 
 노트는 자동으로 `~/Documents/Synapse/notes/`에 저장됩니다.
+
+#### macOS 보안 경고 해결
+
+macOS에서 "손상되어 열 수 없습니다" 또는 "확인할 수 없습니다" 경고가 나타나면, 터미널에서 다음 명령어를 실행하세요:
+
+```bash
+xattr -cr /Applications/Synapse.app
+```
+
+그 후 앱을 다시 실행하면 정상적으로 열립니다.
 
 ### 개발 환경 설정
 

--- a/package.json
+++ b/package.json
@@ -65,20 +65,37 @@
       "public/**/*",
       "notes/**/*"
     ],
-    "asar": true,
-    "asarUnpack": [
-      ".next/standalone/**",
-      "notes/**"
-    ],
+    "asar": false,
     "directories": {
       "buildResources": "assets"
     },
     "mac": {
       "category": "public.app-category.productivity",
-      "target": [
-        "dmg"
-      ],
+      "target": {
+        "target": "dmg",
+        "arch": ["arm64", "x64"]
+      },
       "icon": "assets/synapse-icon-ios.icns"
+    },
+    "dmg": {
+      "title": "${productName} ${version}",
+      "icon": "assets/synapse-icon-ios.icns",
+      "contents": [
+        {
+          "x": 130,
+          "y": 220
+        },
+        {
+          "x": 410,
+          "y": 220,
+          "type": "link",
+          "path": "/Applications"
+        }
+      ],
+      "window": {
+        "width": 540,
+        "height": 380
+      }
     },
     "win": {
       "target": [


### PR DESCRIPTION
## 릴리즈 내용

### 빌드 시스템 개선
- 워크플로우 단순화 (불필요한 ad-hoc 서명 제거)
- macOS 전용 빌드로 집중 (Windows/Linux 제거)
- 빌드 프로세스 간소화

### 사용자 경험 개선
- README에 macOS 보안 경고 해결 방법 추가
- 설치 가이드 업데이트

### 기술 변경
- GitHub Actions 워크플로우 최적화
- electron-builder 설정 정리

## 테스트 완료
- 로컬 빌드 테스트 완료
- macOS 앱 실행 확인