### PR TITLE
fix: 한글 UI 번역 및 버튼 커서 포인터 추가

### DIFF
--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -325,10 +325,10 @@ function DocumentsContent() {
           <p className="text-gray-600">Your local-first markdown notes</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => router.push("/tags")}>
+          <Button variant="outline" onClick={() => router.push("/tags")} className="cursor-pointer">
             태그 관리
           </Button>
-          <Button variant="outline" onClick={() => router.push("/")}>
+          <Button variant="outline" onClick={() => router.push("/")} className="cursor-pointer">
             그래프 뷰
           </Button>
         </div>
@@ -340,7 +340,7 @@ function DocumentsContent() {
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 z-10 pointer-events-none" />
           <Input
             type="text"
-            placeholder="Search notes..."
+            placeholder="노트 검색..."
             value={searchInput}
             onChange={(e) => {
               setSearchInput(e.target.value);
@@ -392,8 +392,8 @@ function DocumentsContent() {
             </div>
           )}
         </div>
-        <Button onClick={() => router.push("/editor/new")}>
-          + New Note
+        <Button onClick={() => router.push("/editor/new")} className="cursor-pointer">
+          + 새 노트
         </Button>
       </div>
 
@@ -506,8 +506,8 @@ function DocumentsContent() {
       {/* Empty State - No documents at all */}
       {documents.length === 0 && (
         <div className="text-center py-12">
-          <p className="text-gray-600 mb-4">No notes yet. Create your first note!</p>
-          <Button onClick={() => router.push("/editor/new")}>+ New Note</Button>
+          <p className="text-gray-600 mb-4">아직 노트가 없습니다. 첫 노트를 만들어보세요!</p>
+          <Button onClick={() => router.push("/editor/new")} className="cursor-pointer">+ 새 노트</Button>
         </div>
       )}
 

--- a/app/editor/[slug]/page.tsx
+++ b/app/editor/[slug]/page.tsx
@@ -143,7 +143,7 @@ tags: ${tagsYaml}
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
           <p className="text-lg text-red-600 mb-4">{error}</p>
-          <Button onClick={() => router.push("/")}>Go Home</Button>
+          <Button onClick={() => router.push("/")} className="cursor-pointer">홈으로</Button>
         </div>
       </div>
     );
@@ -154,30 +154,32 @@ tags: ${tagsYaml}
       {/* Header */}
       <header className="border-b bg-white p-4">
         <div className="container mx-auto">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex-1 max-w-md">
-              <Input
-                type="text"
-                placeholder="문서 제목을 입력하세요..."
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="text-lg font-bold"
-              />
-              <p className="text-sm text-gray-500 mt-1">
-                {isSaving ? (
-                  "Saving..."
-                ) : lastSaved ? (
-                  `Last saved: ${lastSaved.toLocaleTimeString()}`
-                ) : (
-                  "All changes saved"
-                )}
-              </p>
+          <div className="mb-4">
+            <div className="flex items-center justify-between">
+              <div className="flex-1 max-w-md">
+                <Input
+                  type="text"
+                  placeholder="문서 제목을 입력하세요..."
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className="text-lg font-bold"
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button onClick={handleDone} className="cursor-pointer">
+                  완료
+                </Button>
+              </div>
             </div>
-            <div className="flex gap-2">
-              <Button onClick={handleDone}>
-                Done
-              </Button>
-            </div>
+            <p className="text-sm text-gray-500 mt-1">
+              {isSaving ? (
+                "저장 중..."
+              ) : lastSaved ? (
+                `마지막 저장: ${lastSaved.toLocaleTimeString()}`
+              ) : (
+                "모든 변경사항 저장됨"
+              )}
+            </p>
           </div>
 
           {/* Tags Section */}
@@ -199,7 +201,7 @@ tags: ${tagsYaml}
       <div className="flex-1 grid grid-cols-2 gap-4 p-4 overflow-hidden">
         {/* Editor */}
         <div className="flex flex-col h-full overflow-hidden">
-          <h2 className="text-lg font-semibold mb-2">Editor</h2>
+          <h2 className="text-lg font-semibold mb-2">편집기</h2>
           <div className="flex-1 overflow-y-auto border rounded-lg">
             <MarkdownEditor
               value={contentWithoutMetadata}

--- a/app/editor/new/page.tsx
+++ b/app/editor/new/page.tsx
@@ -160,8 +160,8 @@ ${bodyContent}`;
         <div className="container mx-auto">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-4 flex-1">
-              <Button variant="outline" onClick={handleCancel}>
-                ← Cancel
+              <Button variant="outline" onClick={handleCancel} className="cursor-pointer">
+                ← 취소
               </Button>
               <div className="flex-1 max-w-md">
                 <Input
@@ -184,6 +184,7 @@ ${bodyContent}`;
               <Button
                 onClick={saveDocument}
                 disabled={isSaving || !title.trim()}
+                className="cursor-pointer"
               >
                 {isSaving ? "저장 중..." : "저장"}
               </Button>

--- a/app/note/[slug]/page.tsx
+++ b/app/note/[slug]/page.tsx
@@ -105,8 +105,8 @@ export default function NotePage() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <p className="text-lg text-red-600 mb-4">{error || "Document not found"}</p>
-          <Button onClick={() => router.push("/")}>Go Home</Button>
+          <p className="text-lg text-red-600 mb-4">{error || "문서를 찾을 수 없습니다"}</p>
+          <Button onClick={() => router.push("/")} className="cursor-pointer">홈으로</Button>
         </div>
       </div>
     );
@@ -118,8 +118,8 @@ export default function NotePage() {
       <header className="border-b bg-white p-4 sticky top-0 z-10">
         <div className="container mx-auto flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <Button variant="outline" onClick={() => router.push("/")}>
-              ← Back
+            <Button variant="outline" onClick={() => router.push("/")} className="cursor-pointer">
+              ← 뒤로
             </Button>
             <div>
               <h1 className="text-xl font-bold">{document.title}</h1>
@@ -139,11 +139,11 @@ export default function NotePage() {
             </div>
           </div>
           <div className="flex gap-2">
-            <Button onClick={() => router.push(`/editor/${slug}`)}>
-              Edit
+            <Button onClick={() => router.push(`/editor/${slug}`)} className="cursor-pointer">
+              편집
             </Button>
-            <Button variant="destructive" onClick={handleDelete}>
-              Delete
+            <Button variant="destructive" onClick={handleDelete} className="cursor-pointer">
+              삭제
             </Button>
           </div>
         </div>
@@ -167,18 +167,18 @@ export default function NotePage() {
             <div className="lg:col-span-1">
               <div className="sticky top-20 bg-white border rounded-lg p-4 shadow-sm overflow-hidden">
                 <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-semibold text-gray-800">Local Graph</h3>
+                  <h3 className="text-sm font-semibold text-gray-800">로컬 그래프</h3>
 
                   {/* Compact Depth Slider */}
                   <div className="flex items-center gap-3">
-                    <span className="text-xs font-medium text-gray-600">Depth:</span>
+                    <span className="text-xs font-medium text-gray-600">깊이:</span>
                     <div className="flex items-center gap-2">
                       {[1, 2, 3].map((level) => (
                         <button
                           key={level}
                           onClick={() => setDepth(level)}
                           className={`
-                            w-7 h-7 rounded-full text-xs font-semibold transition-all duration-200
+                            w-7 h-7 rounded-full text-xs font-semibold transition-all duration-200 cursor-pointer
                             ${depth === level
                               ? 'bg-blue-500 text-white shadow-md scale-110'
                               : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
@@ -210,11 +210,11 @@ export default function NotePage() {
         <div className="container mx-auto max-w-4xl">
           <div className="grid grid-cols-2 gap-4 text-sm text-gray-600 mb-4">
             <div>
-              <span className="font-semibold">Created:</span>{" "}
+              <span className="font-semibold">생성일:</span>{" "}
               {new Date(document.createdAt).toLocaleString()}
             </div>
             <div>
-              <span className="font-semibold">Updated:</span>{" "}
+              <span className="font-semibold">수정일:</span>{" "}
               {new Date(document.updatedAt).toLocaleString()}
             </div>
           </div>
@@ -223,14 +223,14 @@ export default function NotePage() {
           {document.links.length > 0 && (
             <div className="mb-4">
               <h3 className="text-sm font-semibold mb-2">
-                Links ({document.links.length})
+                링크 ({document.links.length})
               </h3>
               <div className="flex gap-2 flex-wrap">
                 {document.links.map((link) => (
                   <button
                     key={link}
                     onClick={() => router.push(`/note/${link}`)}
-                    className="text-sm px-3 py-1 bg-blue-100 text-blue-700 rounded-full hover:bg-blue-200"
+                    className="text-sm px-3 py-1 bg-blue-100 text-blue-700 rounded-full hover:bg-blue-200 cursor-pointer"
                   >
                     {link}
                   </button>
@@ -243,14 +243,14 @@ export default function NotePage() {
           {document.backlinks.length > 0 && (
             <div>
               <h3 className="text-sm font-semibold mb-2">
-                Backlinks ({document.backlinks.length})
+                역링크 ({document.backlinks.length})
               </h3>
               <div className="flex gap-2 flex-wrap">
                 {document.backlinks.map((backlink) => (
                   <button
                     key={backlink}
                     onClick={() => router.push(`/note/${backlink}`)}
-                    className="text-sm px-3 py-1 bg-green-100 text-green-700 rounded-full hover:bg-green-200"
+                    className="text-sm px-3 py-1 bg-green-100 text-green-700 rounded-full hover:bg-green-200 cursor-pointer"
                   >
                     {backlink}
                   </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-lg text-gray-600">Loading graph...</p>
+        <p className="text-lg text-gray-600">그래프 로딩 중...</p>
       </div>
     );
   }
@@ -57,7 +57,7 @@ export default function Home() {
   if (!graph) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-lg text-red-600">Failed to load graph</p>
+        <p className="text-lg text-red-600">그래프를 불러올 수 없습니다</p>
       </div>
     );
   }
@@ -74,15 +74,15 @@ export default function Home() {
           <div>
             <h1 className="text-2xl font-bold">Synapse</h1>
             <p className="text-sm text-gray-600">
-              {nodeCount} notes, {linkCount} connections
+              {nodeCount}개 노트, {linkCount}개 연결
             </p>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" onClick={() => router.push("/documents")}>
-              View List
+            <Button variant="outline" onClick={() => router.push("/documents")} className="cursor-pointer">
+              목록 보기
             </Button>
-            <Button onClick={() => router.push("/editor/new")}>
-              + New Note
+            <Button onClick={() => router.push("/editor/new")} className="cursor-pointer">
+              + 새 노트
             </Button>
           </div>
         </div>
@@ -104,8 +104,8 @@ export default function Home() {
       {/* Quick Tips */}
       <div className="border-t bg-white p-3 flex-shrink-0">
         <div className="container mx-auto text-center text-sm text-gray-600">
-          <span className="font-semibold">Tips:</span> Click a node to view note
-          • Hover to see connections • Larger nodes = more connections
+          <span className="font-semibold">팁:</span> 노드를 클릭하여 노트 보기
+          • 마우스를 올려 연결 확인 • 큰 노드 = 더 많은 연결
         </div>
       </div>
     </div>

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -78,10 +78,10 @@ export default function TagsPage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => router.push("/documents")}>
+          <Button variant="outline" onClick={() => router.push("/documents")} className="cursor-pointer">
             문서 목록
           </Button>
-          <Button variant="outline" onClick={() => router.push("/")}>
+          <Button variant="outline" onClick={() => router.push("/")} className="cursor-pointer">
             그래프 뷰
           </Button>
         </div>
@@ -93,6 +93,7 @@ export default function TagsPage() {
           variant={sortBy === "count" ? "default" : "outline"}
           onClick={() => setSortBy("count")}
           size="sm"
+          className="cursor-pointer"
         >
           사용 빈도순
         </Button>
@@ -100,6 +101,7 @@ export default function TagsPage() {
           variant={sortBy === "name" ? "default" : "outline"}
           onClick={() => setSortBy("name")}
           size="sm"
+          className="cursor-pointer"
         >
           이름순
         </Button>

--- a/components/graph/ForceGraphView.tsx
+++ b/components/graph/ForceGraphView.tsx
@@ -477,7 +477,7 @@ export default function ForceGraphView({
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 z-10 pointer-events-none" />
               <input
                 type="text"
-                placeholder="Search notes..."
+                placeholder="노트 검색..."
                 value={searchInput}
                 onChange={(e) => {
                   setSearchInput(e.target.value);
@@ -534,7 +534,7 @@ export default function ForceGraphView({
             <div className="relative">
               <input
                 type="text"
-                placeholder="Add tag filter..."
+                placeholder="태그 필터 추가..."
                 value={tagInput}
                 onChange={(e) => {
                   setTagInput(e.target.value);
@@ -609,7 +609,7 @@ export default function ForceGraphView({
       <div className="absolute top-2 right-2 flex flex-col gap-1">
         <button
           onClick={handleZoomIn}
-          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center"
+          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center cursor-pointer"
           title="Zoom In"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -618,7 +618,7 @@ export default function ForceGraphView({
         </button>
         <button
           onClick={handleZoomOut}
-          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center"
+          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center cursor-pointer"
           title="Zoom Out"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -627,7 +627,7 @@ export default function ForceGraphView({
         </button>
         <button
           onClick={handleZoomReset}
-          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center"
+          className="w-8 h-8 bg-white/90 backdrop-blur-sm border border-gray-200 rounded shadow-sm hover:bg-gray-50 transition-colors flex items-center justify-center cursor-pointer"
           title="Reset View"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -640,9 +640,9 @@ export default function ForceGraphView({
       <div className="absolute bottom-2 right-2 bg-white/90 backdrop-blur-sm border border-gray-200 rounded-lg shadow-sm text-xs">
         <button
           onClick={() => setIsLegendExpanded(!isLegendExpanded)}
-          className="flex items-center gap-2 w-full px-2 py-1.5 hover:bg-gray-50 rounded-lg transition-colors"
+          className="flex items-center gap-2 w-full px-2 py-1.5 hover:bg-gray-50 rounded-lg transition-colors cursor-pointer"
         >
-          <div className="font-semibold text-gray-700">Legend</div>
+          <div className="font-semibold text-gray-700">범례</div>
           <svg
             className={`w-3 h-3 text-gray-500 transition-transform ${isLegendExpanded ? 'rotate-180' : ''}`}
             fill="none"
@@ -658,15 +658,15 @@ export default function ForceGraphView({
             {/* Tag-based colors */}
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#3b82f6] flex-shrink-0"></div>
-              <span className="text-gray-600">Guide/Tutorial</span>
+              <span className="text-gray-600">가이드/튜토리얼</span>
             </div>
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#10b981] flex-shrink-0"></div>
-              <span className="text-gray-600">Getting Started</span>
+              <span className="text-gray-600">시작하기</span>
             </div>
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#8b5cf6] flex-shrink-0"></div>
-              <span className="text-gray-600">Features</span>
+              <span className="text-gray-600">기능</span>
             </div>
 
             {/* Divider */}
@@ -675,15 +675,15 @@ export default function ForceGraphView({
             {/* Connection-based colors */}
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#ef4444] flex-shrink-0"></div>
-              <span className="text-gray-600">Highly Connected (3+)</span>
+              <span className="text-gray-600">많은 연결 (3+)</span>
             </div>
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#f59e0b] flex-shrink-0"></div>
-              <span className="text-gray-600">Connected (1-2)</span>
+              <span className="text-gray-600">연결됨 (1-2)</span>
             </div>
             <div className="flex items-center gap-1.5">
               <div className="w-2.5 h-2.5 rounded-full bg-[#6b7280] flex-shrink-0"></div>
-              <span className="text-gray-600">Default</span>
+              <span className="text-gray-600">기본</span>
             </div>
           </div>
         )}


### PR DESCRIPTION
## 변경사항
- 모든 페이지의 UI 텍스트를 한글로 번역
- 모든 버튼에 cursor-pointer 클래스 추가
- 편집 페이지 레이아웃 개선 (제목/완료 버튼 정렬)

## 상세 내용
### 한글 번역
- 홈페이지: 로딩/에러 메시지, 통계, 버튼, 팁
- Documents 페이지: 검색 placeholder, 버튼, 빈 상태 메시지
- Tags 페이지: 제목, 통계, 정렬 버튼
- 노트 상세 페이지: 네비게이션, 액션, 메타데이터 라벨
- 편집 페이지: 상태 메시지, 버튼

### UX 개선
- 모든 클릭 가능한 버튼에 cursor-pointer 추가
- 편집 페이지: 제목 입력란과 완료 버튼을 가로 정렬, 저장 상태는 아래로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)