### PR TITLE
feat: OAuth Proxy 추가

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,15 @@
 # Published mode (set to "true" when deploying read-only version)
 NEXT_PUBLIC_IS_PUBLISHED=false
+
+# OAuth Proxy URL (required for Electron app distribution)
+# Set this to your deployed OAuth proxy URL (e.g., https://synapse-oauth-proxy.vercel.app)
+# If not set, the app will use local OAuth endpoints (requires GITHUB_CLIENT_ID, etc.)
+NEXT_PUBLIC_OAUTH_PROXY_URL=
+
+# Local OAuth (only needed for development without OAuth Proxy)
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
+# VERCEL_CLIENT_ID=
+# VERCEL_CLIENT_SECRET=
+# VERCEL_REDIRECT_URI=http://localhost:3000/api/auth/vercel/callback

--- a/app/api/auth/github/save/route.ts
+++ b/app/api/auth/github/save/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { saveGitHubToken } from '@/lib/github-token';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { accessToken, username, userId } = body;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { success: false, error: 'Missing access token' },
+        { status: 400 }
+      );
+    }
+
+    await saveGitHubToken({
+      accessToken,
+      username: username || undefined,
+      userId: userId || undefined,
+      createdAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error saving GitHub token:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to save token' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/vercel/save/route.ts
+++ b/app/api/auth/vercel/save/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { saveVercelToken } from '@/lib/vercel-token';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { accessToken, teamId, userId, installationId } = body;
+
+    if (!accessToken) {
+      return NextResponse.json(
+        { success: false, error: 'Missing access token' },
+        { status: 400 }
+      );
+    }
+
+    await saveVercelToken({
+      accessToken,
+      teamId: teamId || undefined,
+      userId: userId || undefined,
+      installationId: installationId || undefined,
+      createdAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error saving Vercel token:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to save token' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/oauth/callback/page.tsx
+++ b/app/oauth/callback/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function OAuthCallbackPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [status, setStatus] = useState<'processing' | 'success' | 'error'>('processing');
+  const [message, setMessage] = useState('OAuth 처리 중...');
+
+  useEffect(() => {
+    const processCallback = async () => {
+      const data = searchParams.get('data');
+      const error = searchParams.get('error');
+      const provider = searchParams.get('provider');
+
+      if (error) {
+        setStatus('error');
+        const errorMessages: Record<string, string> = {
+          missing_params: '필수 파라미터가 누락되었습니다.',
+          invalid_state: '잘못된 상태값입니다.',
+          csrf_mismatch: 'CSRF 토큰이 일치하지 않습니다.',
+          config_error: 'OAuth 설정 오류입니다.',
+          token_exchange_failed: '토큰 교환에 실패했습니다.',
+          no_access_token: '액세스 토큰을 받지 못했습니다.',
+          oauth_failed: 'OAuth 인증에 실패했습니다.',
+          missing_code: '인증 코드가 누락되었습니다.',
+        };
+        setMessage(errorMessages[error] || `오류: ${error}`);
+
+        // Redirect to settings with error after delay
+        setTimeout(() => {
+          router.replace(`/settings?error=${error}`);
+        }, 2000);
+        return;
+      }
+
+      if (!data || !provider) {
+        setStatus('error');
+        setMessage('토큰 데이터 또는 provider가 누락되었습니다.');
+        setTimeout(() => {
+          router.replace('/settings?error=missing_data');
+        }, 2000);
+        return;
+      }
+
+      try {
+        // Parse token data
+        const tokenData = JSON.parse(decodeURIComponent(data));
+
+        // Save token via API
+        const response = await fetch(`/api/auth/${provider}/save`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(tokenData),
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          setStatus('success');
+          setMessage(`${provider === 'github' ? 'GitHub' : 'Vercel'} 연동 완료!`);
+          setTimeout(() => {
+            router.replace(`/settings?success=${provider}_connected`);
+          }, 1000);
+        } else {
+          throw new Error(result.error || 'Failed to save token');
+        }
+      } catch (err) {
+        console.error('Error processing OAuth callback:', err);
+        setStatus('error');
+        setMessage('토큰 저장에 실패했습니다.');
+        setTimeout(() => {
+          router.replace('/settings?error=save_failed');
+        }, 2000);
+      }
+    };
+
+    processCallback();
+  }, [searchParams, router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background">
+      <div className="text-center p-8">
+        {status === 'processing' && (
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4" />
+        )}
+        {status === 'success' && (
+          <div className="text-4xl mb-4">✓</div>
+        )}
+        {status === 'error' && (
+          <div className="text-4xl mb-4">✕</div>
+        )}
+        <p className="text-lg">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -134,11 +134,29 @@ function SettingsContent() {
   }
 
   function handleConnectVercel() {
-    window.location.href = '/api/auth/vercel/start';
+    // Use OAuth Proxy if configured, otherwise fall back to local OAuth
+    const proxyUrl = process.env.NEXT_PUBLIC_OAUTH_PROXY_URL;
+    const callbackUrl = encodeURIComponent(`${window.location.origin}/oauth/callback`);
+
+    if (proxyUrl) {
+      window.location.href = `${proxyUrl}/api/vercel/start?callback_url=${callbackUrl}`;
+    } else {
+      // Fallback for local development with .env.local
+      window.location.href = '/api/auth/vercel/start';
+    }
   }
 
   function handleConnectGitHub() {
-    window.location.href = '/api/auth/github/start';
+    // Use OAuth Proxy if configured, otherwise fall back to local OAuth
+    const proxyUrl = process.env.NEXT_PUBLIC_OAUTH_PROXY_URL;
+    const callbackUrl = encodeURIComponent(`${window.location.origin}/oauth/callback`);
+
+    if (proxyUrl) {
+      window.location.href = `${proxyUrl}/api/github/start?callback_url=${callbackUrl}`;
+    } else {
+      // Fallback for local development with .env.local
+      window.location.href = '/api/auth/github/start';
+    }
   }
 
   async function handleDisconnectVercel() {

--- a/oauth-proxy/.env.local.example
+++ b/oauth-proxy/.env.local.example
@@ -1,0 +1,9 @@
+# GitHub OAuth
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+GITHUB_REDIRECT_URI=https://your-oauth-proxy.vercel.app/api/github/callback
+
+# Vercel OAuth
+VERCEL_CLIENT_ID=your_vercel_client_id
+VERCEL_CLIENT_SECRET=your_vercel_client_secret
+VERCEL_REDIRECT_URI=https://your-oauth-proxy.vercel.app/api/vercel/callback

--- a/oauth-proxy/.gitignore
+++ b/oauth-proxy/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.vercel
+.env.local
+dist

--- a/oauth-proxy/api/github/callback.ts
+++ b/oauth-proxy/api/github/callback.ts
@@ -1,0 +1,97 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+interface StatePayload {
+  csrf: string;
+  callback: string;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { code, state } = req.query;
+
+  // Default error redirect
+  const defaultCallback = 'http://localhost:3000/oauth/callback';
+
+  if (!code || !state) {
+    return res.redirect(`${defaultCallback}?error=missing_params&provider=github`);
+  }
+
+  // Decode state to get CSRF token and callback URL
+  let statePayload: StatePayload;
+  try {
+    statePayload = JSON.parse(Buffer.from(state as string, 'base64url').toString());
+  } catch {
+    return res.redirect(`${defaultCallback}?error=invalid_state&provider=github`);
+  }
+
+  // Verify CSRF token from cookie
+  const cookies = req.headers.cookie || '';
+  const storedState = cookies.match(/github_oauth_state=([^;]+)/)?.[1];
+
+  if (!storedState || storedState !== statePayload.csrf) {
+    return res.redirect(`${statePayload.callback || defaultCallback}?error=csrf_mismatch&provider=github`);
+  }
+
+  // Exchange code for access token
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+  const redirectUri = process.env.GITHUB_REDIRECT_URI;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    return res.redirect(`${statePayload.callback}?error=config_error&provider=github`);
+  }
+
+  try {
+    const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
+
+    const tokenData = await tokenResponse.json();
+
+    if (tokenData.error || !tokenData.access_token) {
+      console.error('GitHub token exchange error:', tokenData);
+      return res.redirect(`${statePayload.callback}?error=token_exchange_failed&provider=github`);
+    }
+
+    // Get user info
+    const userResponse = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${tokenData.access_token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    const userData = await userResponse.json();
+
+    // Clear CSRF cookie
+    res.setHeader(
+      'Set-Cookie',
+      `github_oauth_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/`
+    );
+
+    // Encode token data for redirect
+    const tokenPayload = encodeURIComponent(
+      JSON.stringify({
+        accessToken: tokenData.access_token,
+        username: userData.login,
+        userId: userData.id?.toString(),
+      })
+    );
+
+    // Redirect back to app with token data
+    res.redirect(`${statePayload.callback}?data=${tokenPayload}&provider=github`);
+  } catch (error) {
+    console.error('GitHub OAuth error:', error);
+    return res.redirect(`${statePayload.callback}?error=oauth_failed&provider=github`);
+  }
+}

--- a/oauth-proxy/api/github/start.ts
+++ b/oauth-proxy/api/github/start.ts
@@ -1,0 +1,36 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import crypto from 'crypto';
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const redirectUri = process.env.GITHUB_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    return res.status(500).json({ error: 'GitHub OAuth not configured' });
+  }
+
+  // Get callback URL from query params (where to redirect after OAuth)
+  const callbackUrl = (req.query.callback_url as string) || 'http://localhost:3000/oauth/callback';
+
+  // Generate CSRF state token
+  const csrfToken = crypto.randomBytes(32).toString('hex');
+
+  // Encode callback URL and CSRF token in state
+  const statePayload = JSON.stringify({ csrf: csrfToken, callback: callbackUrl });
+  const encodedState = Buffer.from(statePayload).toString('base64url');
+
+  // Build GitHub OAuth URL
+  const authUrl = new URL('https://github.com/login/oauth/authorize');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('state', encodedState);
+  authUrl.searchParams.set('scope', 'repo');
+
+  // Set CSRF cookie for verification in callback
+  res.setHeader(
+    'Set-Cookie',
+    `github_oauth_state=${csrfToken}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`
+  );
+
+  res.redirect(authUrl.toString());
+}

--- a/oauth-proxy/api/vercel/callback.ts
+++ b/oauth-proxy/api/vercel/callback.ts
@@ -1,0 +1,98 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+interface StatePayload {
+  csrf: string;
+  callback: string;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { code, configurationId, teamId, state } = req.query;
+
+  // Default error redirect
+  const defaultCallback = 'http://localhost:3000/oauth/callback';
+
+  if (!code) {
+    return res.redirect(`${defaultCallback}?error=missing_code&provider=vercel`);
+  }
+
+  // Decode state to get CSRF token and callback URL
+  let statePayload: StatePayload | null = null;
+  let callbackUrl = defaultCallback;
+
+  if (state) {
+    try {
+      statePayload = JSON.parse(Buffer.from(state as string, 'base64url').toString());
+      callbackUrl = statePayload.callback || defaultCallback;
+
+      // Verify CSRF token from cookie
+      const cookies = req.headers.cookie || '';
+      const storedState = cookies.match(/vercel_oauth_state=([^;]+)/)?.[1];
+
+      if (!storedState || storedState !== statePayload.csrf) {
+        return res.redirect(`${callbackUrl}?error=csrf_mismatch&provider=vercel`);
+      }
+    } catch {
+      // State parsing failed, continue without CSRF check for backward compatibility
+      console.warn('Failed to parse state, continuing without CSRF check');
+    }
+  }
+
+  // Exchange code for access token
+  const clientId = process.env.VERCEL_CLIENT_ID;
+  const clientSecret = process.env.VERCEL_CLIENT_SECRET;
+  const redirectUri = process.env.VERCEL_REDIRECT_URI;
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    return res.redirect(`${callbackUrl}?error=config_error&provider=vercel`);
+  }
+
+  try {
+    const tokenResponse = await fetch('https://api.vercel.com/v2/oauth/access_token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: code as string,
+        redirect_uri: redirectUri,
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const errorText = await tokenResponse.text();
+      console.error('Vercel token exchange error:', errorText);
+      return res.redirect(`${callbackUrl}?error=token_exchange_failed&provider=vercel`);
+    }
+
+    const tokenData = await tokenResponse.json();
+
+    if (!tokenData.access_token) {
+      console.error('No access token in response:', tokenData);
+      return res.redirect(`${callbackUrl}?error=no_access_token&provider=vercel`);
+    }
+
+    // Clear CSRF cookie
+    res.setHeader(
+      'Set-Cookie',
+      `vercel_oauth_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/`
+    );
+
+    // Encode token data for redirect
+    const tokenPayload = encodeURIComponent(
+      JSON.stringify({
+        accessToken: tokenData.access_token,
+        teamId: tokenData.team_id || teamId || null,
+        userId: tokenData.user_id || null,
+        installationId: tokenData.installation_id || configurationId || null,
+      })
+    );
+
+    // Redirect back to app with token data
+    res.redirect(`${callbackUrl}?data=${tokenPayload}&provider=vercel`);
+  } catch (error) {
+    console.error('Vercel OAuth error:', error);
+    return res.redirect(`${callbackUrl}?error=oauth_failed&provider=vercel`);
+  }
+}

--- a/oauth-proxy/api/vercel/start.ts
+++ b/oauth-proxy/api/vercel/start.ts
@@ -1,0 +1,34 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import crypto from 'crypto';
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  const clientId = process.env.VERCEL_CLIENT_ID;
+  const redirectUri = process.env.VERCEL_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    return res.status(500).json({ error: 'Vercel OAuth not configured' });
+  }
+
+  // Get callback URL from query params (where to redirect after OAuth)
+  const callbackUrl = (req.query.callback_url as string) || 'http://localhost:3000/oauth/callback';
+
+  // Generate CSRF state token
+  const csrfToken = crypto.randomBytes(32).toString('hex');
+
+  // Encode callback URL and CSRF token in state
+  const statePayload = JSON.stringify({ csrf: csrfToken, callback: callbackUrl });
+  const encodedState = Buffer.from(statePayload).toString('base64url');
+
+  // Vercel uses integration installation flow
+  // The integration page will redirect to our callback with code and configurationId
+  const authUrl = new URL('https://vercel.com/integrations/synapse-notes/new');
+  authUrl.searchParams.set('state', encodedState);
+
+  // Set CSRF cookie for verification in callback
+  res.setHeader(
+    'Set-Cookie',
+    `vercel_oauth_state=${csrfToken}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`
+  );
+
+  res.redirect(authUrl.toString());
+}

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "synapse-oauth-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vercel dev --listen 3001",
+    "deploy": "vercel --prod"
+  },
+  "devDependencies": {
+    "@vercel/node": "^3.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/oauth-proxy/tsconfig.json
+++ b/oauth-proxy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["api/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/oauth-proxy/vercel.json
+++ b/oauth-proxy/vercel.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "name": "synapse-oauth-proxy",
+  "regions": ["icn1"],
+  "functions": {
+    "api/**/*.ts": {
+      "memory": 128,
+      "maxDuration": 10
+    }
+  },
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, OPTIONS"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Electron 앱 배포 시 OAuth 자격 증명 문제 해결을 위한 OAuth Proxy 추가
- oauth-proxy/ 폴더는 별도 Vercel 프로젝트로 배포됨
- 앱에서는 NEXT_PUBLIC_OAUTH_PROXY_URL 환경변수로 프록시 URL 설정

## Changes
- `oauth-proxy/` - 별도 Vercel 서버리스 함수 프로젝트
  - GitHub OAuth (start, callback)
  - Vercel OAuth (start, callback)
- `app/oauth/callback/page.tsx` - OAuth 콜백 처리 페이지
- `app/api/auth/{github,vercel}/save/route.ts` - 토큰 저장 API
- `app/settings/page.tsx` - OAuth Proxy URL 사용하도록 수정
- `.env.local.example` - NEXT_PUBLIC_OAUTH_PROXY_URL 추가

## Test plan
- [ ] oauth-proxy를 Vercel에 배포
- [ ] Vercel 환경변수에 OAuth 자격 증명 설정
- [ ] GitHub/Vercel OAuth 앱 redirect URI 업데이트
- [ ] Electron 앱에서 OAuth 연동 테스트