### PR TITLE
fix: 프로덕션 빌드 시 동적 포트 할당

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "eslint",
     "electron:dev": "concurrently \"npm run dev\" \"wait-on http://localhost:3000 && cross-env NODE_ENV=development electron .\"",
-    "electron:build": "next build && npm run copy-assets && electron-builder",
+    "electron:build": "rm -rf dist && next build && npm run copy-assets && electron-builder",
     "copy-assets": "node scripts/copy-assets.js"
   },
   "dependencies": {
@@ -74,7 +74,10 @@
       "category": "public.app-category.productivity",
       "target": {
         "target": "dmg",
-        "arch": ["arm64", "x64"]
+        "arch": [
+          "arm64",
+          "x64"
+        ]
       },
       "icon": "assets/synapse-icon-ios.icns"
     },


### PR DESCRIPTION
프로덕션 빌드에서 포트 3000이 이미 사용 중일 때 자동으로 다른 포트를 찾아 실행하도록 수정

- 3000~3100 범위에서 사용 가능한 포트 자동 탐색
- 개발 모드는 기존대로 3000 고정
- 빌드 스크립트에 dist 폴더 정리 추가