### PR TITLE
fix: 한글 slug 위키링크 연결 문제 해결

### DIFF
--- a/app/editor/[slug]/page.tsx
+++ b/app/editor/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TagInput } from "@/components/ui/tag-input";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { normalizeSlug } from "@/lib/document-parser";
 
 export default function EditorPage() {
   const params = useParams();
@@ -195,8 +196,7 @@ ${editorContent}`;
   }
 
   function handleWikiLinkClick(pageName: string) {
-    const normalizedSlug = pageName.toLowerCase().replace(/\s+/g, "-");
-    router.push(`/note/${normalizedSlug}`);
+    router.push(`/note/${normalizeSlug(pageName)}`);
   }
 
   if (isLoading) {

--- a/app/editor/new/page.tsx
+++ b/app/editor/new/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TagInput } from "@/components/ui/tag-input";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { normalizeSlug } from "@/lib/document-parser";
 
 export default function NewNotePage() {
   const router = useRouter();
@@ -103,7 +104,7 @@ ${bodyContent}`;
       return;
     }
 
-    const slug = title.toLowerCase().replace(/\s+/g, "-");
+    const slug = normalizeSlug(title);
 
     setIsSaving(true);
     setError(null);
@@ -132,9 +133,8 @@ ${bodyContent}`;
   }
 
   function handleWikiLinkClick(pageName: string) {
-    const normalizedSlug = pageName.toLowerCase().replace(/\s+/g, "-");
     // Open in new tab to prevent losing current work
-    window.open(`/note/${normalizedSlug}`, '_blank');
+    window.open(`/note/${normalizeSlug(pageName)}`, '_blank');
   }
 
   async function handleCancel() {

--- a/app/note/[slug]/page.tsx
+++ b/app/note/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { isPublishedMode } from "@/lib/env";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import { normalizeSlug } from "@/lib/document-parser";
 
 export default function NotePage() {
   const params = useParams();
@@ -72,8 +73,7 @@ export default function NotePage() {
   }, [slug]);
 
   function handleWikiLinkClick(pageName: string) {
-    const normalizedSlug = pageName.toLowerCase().replace(/\s+/g, "-");
-    router.push(`/note/${normalizedSlug}`);
+    router.push(`/note/${normalizeSlug(pageName)}`);
   }
 
   async function handleDelete() {

--- a/lib/document-parser.ts
+++ b/lib/document-parser.ts
@@ -52,12 +52,15 @@ export function extractWikiLinks(content: string): string[] {
 /**
  * Normalize a string to a valid slug
  * Example: "Getting Started" -> "getting-started"
+ * Example: "핀테크" -> "핀테크"
+ * Example: "BNPL 서비스" -> "bnpl-서비스"
  */
 export function normalizeSlug(text: string): string {
   return text
     .toLowerCase()
+    .trim()
     .replace(/\s+/g, '-') // spaces to hyphens
-    .replace(/[^a-z0-9-]/g, '') // remove special chars
+    .replace(/[^\p{L}\p{N}-]/gu, '') // keep unicode letters, numbers, hyphens
     .replace(/-+/g, '-') // multiple hyphens to single
     .replace(/^-|-$/g, ''); // remove leading/trailing hyphens
 }


### PR DESCRIPTION
## Summary
- `normalizeSlug` 함수에서 `[^a-z0-9-]` 패턴이 한글을 모두 제거하던 버그 수정
- `[^\p{L}\p{N}-]` 유니코드 패턴으로 변경하여 한글/일본어 등 모든 유니코드 문자 지원
- 위키링크 클릭 핸들러들에서 중복 로직 대신 `normalizeSlug` 함수 재사용

## Test plan
- [ ] `[[핀테크]]` 같은 한글 위키링크가 그래프에서 엣지로 연결되는지 확인
- [ ] 한글 문서 제목으로 새 노트 생성 시 slug가 정상 생성되는지 확인
- [ ] 위키링크 클릭 시 한글 slug 문서로 정상 이동하는지 확인

Closes #32